### PR TITLE
update memfs to ^4.8.2

### DIFF
--- a/packages/@contentlayer/utils/package.json
+++ b/packages/@contentlayer/utils/package.json
@@ -72,7 +72,7 @@
     "chokidar": "^3.5.3",
     "hash-wasm": "^4.11.0",
     "inflection": "^3.0.0",
-    "memfs": "3.6.0",
+    "memfs": "^4.8.2",
     "oo-ascii-tree": "^1.94.0",
     "ts-pattern": "^5.0.6",
     "type-fest": "^4.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,7 +452,7 @@ __metadata:
     chokidar: ^3.5.3
     hash-wasm: ^4.11.0
     inflection: ^3.0.0
-    memfs: 3.6.0
+    memfs: ^4.8.2
     oo-ascii-tree: ^1.94.0
     ts-pattern: ^5.0.6
     type-fest: ^4.10.0
@@ -5215,13 +5215,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-monkey@npm:^1.0.4":
-  version: 1.0.5
-  resolution: "fs-monkey@npm:1.0.5"
-  checksum: 424b67f65b37fe66117ae2bb061f790fe6d4b609e1d160487c74b3d69fbf42f262c665ccfba32e8b5f113f96f92e9a58fcdebe42d5f6649bdfc72918093a3119
-  languageName: node
-  linkType: hard
-
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
@@ -7053,12 +7046,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memfs@npm:3.6.0":
-  version: 3.6.0
-  resolution: "memfs@npm:3.6.0"
+"memfs@npm:^4.8.2":
+  version: 4.8.2
+  resolution: "memfs@npm:4.8.2"
   dependencies:
-    fs-monkey: ^1.0.4
-  checksum: 934e79f32aabb10869056815bf369ed63aacb61d13183a3a3826847bbb359d7023fd5b365984ddd73faed463bbb5370ed5cd1e87ecf50ac010c5cac81929ed78
+    tslib: ^2.0.0
+  checksum: ffbc79e89542c57ccdd83f906252313a8354fb050bab6500728a60a321ca2f090e70145c324ff1540b27272a34ff5049b2790e7d5a9af9ec4505fffeca19db8f
   languageName: node
   linkType: hard
 
@@ -10516,7 +10509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.4.1":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
Since memfs `^4.8.0` [make json-joy and thingies dependencies optional](https://github.com/streamich/memfs/releases/tag/v4.8.0-next.1), we can update to the latest version.

Closes #10 