### PR TITLE
support tsconfig path alias

### DIFF
--- a/packages/@contentlayer/core/src/getConfig/index.ts
+++ b/packages/@contentlayer/core/src/getConfig/index.ts
@@ -224,11 +224,10 @@ const contentlayerGenPlugin = (): esbuild.Plugin => ({
   },
 })
 
-// TODO also take tsconfig.json `paths` mapping into account
 const makeAllPackagesExternalPlugin = (configPath: string): esbuild.Plugin => ({
   name: 'make-all-packages-external',
   setup: (build) => {
-    const filter = /^[^.\/]|^\.[^.\/]|^\.\.[^\/]/ // Must not start with "/" or "./" or "../"
+    const filter = /^[^.\/@~$#]|^\.[^.\/]|^\.\.[^\/]/ // Must not start with "/", "./", "../", "@", "~", "$" or "#"
     build.onResolve({ filter }, (args) => {
       // avoid marking config file as external
       if (args.path.includes(configPath)) {


### PR DESCRIPTION
Fix #38

An alternative way would be to remove `makeAllPackagesExternalPlugin` and use the [packages option](https://esbuild.github.io/api/#packages) in esbuild i.e. `esbuild app.js --bundle --packages=external`. This might restrict supporting older versions of esbuild so I went with modifying the plugin instead. Tested to work locally.