### PR TITLE
add esbuildOptions param to getConfig

### DIFF
--- a/packages/@contentlayer/cli/src/commands/BuildCommand.ts
+++ b/packages/@contentlayer/cli/src/commands/BuildCommand.ts
@@ -21,7 +21,7 @@ export class BuildCommand extends BaseCommand {
   executeSafe = () =>
     pipe(
       this.clearCacheIfNeeded(),
-      T.chain(() => core.getConfig({ configPath: this.configPath })),
+      T.chain(() => core.getConfig({ configPath: this.configPath, esbuildOptions: { external: this.external } })),
       T.tap((config) => (config.source.options.disableImportAliasWarning ? T.unit : T.fork(core.validateTsconfig))),
       T.chain((config) => core.generateDotpkg({ config, verbose: this.verbose })),
       T.tap(core.logGenerateInfo),

--- a/packages/@contentlayer/cli/src/commands/DevCommand.ts
+++ b/packages/@contentlayer/cli/src/commands/DevCommand.ts
@@ -22,7 +22,7 @@ export class DevCommand extends BaseCommand {
   executeSafe = () =>
     pipe(
       S.fromEffect(this.clearCacheIfNeeded()),
-      S.chain(() => core.getConfigWatch({ configPath: this.configPath })),
+      S.chain(() => core.getConfigWatch({ configPath: this.configPath, esbuildOptions: { external: this.external } })),
       S.tapSkipFirstRight(() => T.log(`Contentlayer config change detected. Updating type definitions and data...`)),
       S.tapRight((config) =>
         config.source.options.disableImportAliasWarning ? T.unit : T.fork(core.validateTsconfig),

--- a/packages/@contentlayer/cli/src/commands/_BaseCommand.ts
+++ b/packages/@contentlayer/cli/src/commands/_BaseCommand.ts
@@ -21,6 +21,12 @@ export abstract class BaseCommand extends Command {
     description: 'More verbose logging and error stack traces',
   })
 
+  external = Option.String('--external', {
+    description: 'External dependencies to exclude from the config bundle',
+    validator: t.isArray(t.isString()),
+    required: false,
+  })
+
   abstract executeSafe: () => T.Effect<OT.HasTracer & HasClock & HasCwd & HasConsole & fs.HasFs, unknown, void>
 
   execute = (): Promise<void> =>

--- a/packages/@contentlayer/core/src/getConfig/esbuild.ts
+++ b/packages/@contentlayer/core/src/getConfig/esbuild.ts
@@ -11,6 +11,7 @@ export abstract class EsbuildWatcher {
 
 export type BuildResult = esbuild.BuildResult
 export type Plugin = esbuild.Plugin
+export type BuildOptions = esbuild.BuildOptions
 
 export type EsbuildError = UnknownEsbuildError | KnownEsbuildError
 

--- a/packages/@contentlayer/core/src/getConfig/index.ts
+++ b/packages/@contentlayer/core/src/getConfig/index.ts
@@ -34,12 +34,14 @@ export type Config = {
 
 export const getConfig = ({
   configPath,
+  esbuildOptions,
 }: {
   /** Contentlayer config source path */
   configPath?: string
+  esbuildOptions?: esbuild.BuildOptions
 }): T.Effect<OT.HasTracer & HasCwd & fs.HasFs, GetConfigError, Config> =>
   pipe(
-    getConfigWatch({ configPath }),
+    getConfigWatch({ configPath, esbuildOptions }),
     S.take(1),
     S.runCollect,
     T.map(Chunk.unsafeHead),
@@ -49,8 +51,10 @@ export const getConfig = ({
 
 export const getConfigWatch = ({
   configPath: configPath_,
+  esbuildOptions,
 }: {
   configPath?: string
+  esbuildOptions?: esbuild.BuildOptions
 }): S.Stream<OT.HasTracer & HasCwd & fs.HasFs, never, E.Either<GetConfigError, Config>> => {
   const resolveParams = pipe(
     T.structPar({
@@ -66,6 +70,7 @@ export const getConfigWatch = ({
     S.chainMapEitherRight(({ configPath, outfilePath, cwd }) =>
       pipe(
         esbuild.makeAndSubscribe({
+          ...esbuildOptions,
           entryPoints: [configPath],
           entryNames: '[name]-[hash]',
           outfile: outfilePath,

--- a/packages/contentlayer-stackbit-yaml-generator/src/cli/DefaultCommand.ts
+++ b/packages/contentlayer-stackbit-yaml-generator/src/cli/DefaultCommand.ts
@@ -35,6 +35,12 @@ export class DefaultCommand extends Command {
     validator: t.isString(),
   })
 
+  external = Option.String('--external', {
+    description: 'External dependencies to exclude from the config bundle',
+    validator: t.isArray(t.isString()),
+    required: false,
+  })
+
   // TODO refactor similar to `@contentlayer2/cli`
   async execute() {
     try {
@@ -55,7 +61,7 @@ export class DefaultCommand extends Command {
 
   executeSafe = (): T.Effect<OT.HasTracer & HasCwd & HasConsole & fs.HasFs, unknown, void> =>
     pipe(
-      getConfig({ configPath: this.configPath }),
+      getConfig({ configPath: this.configPath, esbuildOptions: { external: this.external } }),
       T.chain((config) =>
         T.struct({ source: T.succeed(config.source), schema: config.source.provideSchema(config.esbuildHash) }),
       ),

--- a/packages/next-contentlayer/src/plugin.ts
+++ b/packages/next-contentlayer/src/plugin.ts
@@ -3,23 +3,25 @@ import '@contentlayer2/utils/effect/Tracing/Enable'
 import * as core from '@contentlayer2/core'
 import { errorToString } from '@contentlayer2/utils'
 import { E, OT, pipe, S, T } from '@contentlayer2/utils/effect'
+import type * as esbuild from 'esbuild'
 import type { WebpackOptionsNormalized } from 'webpack'
 
 import { checkConstraints } from './check-constraints.js'
 
 export type NextPluginOptions = {
   configPath?: string | undefined
+  esbuildOptions?: Pick<esbuild.BuildOptions, 'external'> | undefined
 }
 
 /** Seems like the next.config.js export function might be executed multiple times, so we need to make sure we only run it once */
 let contentlayerInitialized = false
 
-const runContentlayerDev = async ({ configPath }: NextPluginOptions) => {
+const runContentlayerDev = async ({ configPath, esbuildOptions }: NextPluginOptions) => {
   if (contentlayerInitialized) return
   contentlayerInitialized = true
 
   await pipe(
-    core.getConfigWatch({ configPath }),
+    core.getConfigWatch({ configPath, esbuildOptions }),
     S.tapSkipFirstRight(() => T.log(`Contentlayer config change detected. Updating type definitions and data...`)),
     S.tapRight((config) => (config.source.options.disableImportAliasWarning ? T.unit : T.fork(core.validateTsconfig))),
     S.chainSwitchMapEitherRight((config) => core.generateDotpkgStream({ config, verbose: false, isDev: true })),
@@ -29,12 +31,12 @@ const runContentlayerDev = async ({ configPath }: NextPluginOptions) => {
   )
 }
 
-const runContentlayerBuild = async ({ configPath }: NextPluginOptions) => {
+const runContentlayerBuild = async ({ configPath, esbuildOptions }: NextPluginOptions) => {
   if (contentlayerInitialized) return
   contentlayerInitialized = true
 
   await pipe(
-    core.getConfig({ configPath }),
+    core.getConfig({ configPath, esbuildOptions }),
     T.chain((config) => core.generateDotpkg({ config, verbose: false })),
     T.tap(core.logGenerateInfo),
     OT.withSpan('next-contentlayer:runContentlayerBuild'),
@@ -56,14 +58,14 @@ export const runBeforeWebpackCompile = async ({
   const isNextDev = mode === 'development'
   const isBuild = mode === 'production'
 
-  const { configPath } = pluginOptions
+  const { configPath, esbuildOptions } = pluginOptions
 
   if (isBuild) {
     checkConstraints()
-    await runContentlayerBuild({ configPath })
+    await runContentlayerBuild({ configPath, esbuildOptions })
   } else if (isNextDev && !devServerStartedRef.current) {
     devServerStartedRef.current = true
     // TODO also block here until first Contentlayer run is complete
-    runContentlayerDev({ configPath })
+    runContentlayerDev({ configPath, esbuildOptions })
   }
 }


### PR DESCRIPTION
Currently it only accepts "external" prop as other fields might break the config build process

fix: https://github.com/timlrx/contentlayer2/issues/70

<details><summary>To test this, I updated the `next-contentlayer-example` locally with</summary>
<p>

In file `next.config.js`
```js
const {
	createContentlayerPlugin,
	defaultPluginOptions,
} = require("next-contentlayer2");

/** @type {import('next').NextConfig} */
const nextConfig = {};

const withContentlayer = createContentlayerPlugin({
	...defaultPluginOptions,
	esbuildOptions: {
		external: ["@terrastruct/d2"],
	},
});
module.exports = withContentlayer(nextConfig);
```

`package.json`
```json
{
	"name": "next-contentlayer-example",
	"version": "0.1.0",
	"private": true,
	"scripts": {
		"dev": "next dev",
		"build": "next build",
		"start": "next start"
	},
	"dependencies": {
+		"@terrastruct/d2": "^0.1.23",
+		"contentlayer2": "workspace:*",
		"date-fns": "4.1.0",
		"next": "^15.2.4",
+		"next-contentlayer2": "workspace:*",
		"react": "^19.1.0",
		"react-dom": "^19.1.0"
	},
	"devDependencies": {
		"@tailwindcss/postcss": "4.0.17",
		"@types/react": "19.0.12",
		"postcss": "^8.4.24",
		"tailwindcss": "4.0.17",
		"typescript": "^5.5.0"
	}
}
```
`contentlayer.config.js`
```diff

+ import { D2 } from "@terrastruct/d2";


+const superRehypePlugin = () => {
+  const d2 = new D2();
+
+  return async (tree: unknown) => {
+    const render = await d2.compile("a -> b");
+    return tree;
+  };
+};

export default makeSource({
  contentDirPath: 'posts',
  documentTypes: [Post],
+  mdx: {
+   rehypePlugins: [superRehypePlugin],
+  },
})
```

If you uncomment `external: ["@terrastruct/d2"],` or remove that section entirely, the build / dev will fail.

</p>
</details> 

I haven't found any tests that I could update for this usecase, If you want to add one tell me